### PR TITLE
202210 updates to Anvil schema

### DIFF
--- a/anvil_schema/schema/mapping_schema_object.json
+++ b/anvil_schema/schema/mapping_schema_object.json
@@ -1,8 +1,8 @@
 {
-  "version": 3,
+  "version": 4,
   "tables": [
     {
-      "name": "activity",
+      "name": "anvil_activity",
       "columns": [
         {"name": "activity_id", "datatype": "string", "array_of": false, "required": true},
         {"name": "activity_type", "datatype": "string", "array_of": false, "required": false},
@@ -17,7 +17,7 @@
       "intPartitionOptions": null
     },
     {
-      "name": "alignmentactivity",
+      "name": "anvil_alignmentactivity",
       "columns": [
         {"name": "alignmentactivity_id", "datatype": "string", "array_of": false, "required": true},
         {"name": "activity_type", "datatype": "string", "array_of": false, "required": false},
@@ -33,7 +33,7 @@
       "intPartitionOptions": null
     },
     {
-      "name": "antibody",
+      "name": "anvil_antibody",
       "columns": [
         {"name": "antibody_id", "datatype": "string", "array_of": false, "required": true},
         {"name": "target", "datatype": "string", "array_of": false, "required": false},
@@ -45,7 +45,7 @@
       "intPartitionOptions": null
     },
     {
-      "name": "assayactivity",
+      "name": "anvil_assayactivity",
       "columns": [
         {"name": "assayactivity_id", "datatype": "string", "array_of": false, "required": true},
         {"name": "activity_type", "datatype": "string", "array_of": false, "required": false},
@@ -62,13 +62,12 @@
       "intPartitionOptions": null
     },
     {
-      "name": "biosample",
+      "name": "anvil_biosample",
       "columns": [
         {"name": "biosample_id", "datatype": "string", "array_of": false, "required": true},
         {"name": "anatomical_site", "datatype": "string", "array_of": false, "required": false},
         {"name": "apriori_cell_type", "datatype": "string", "array_of": true, "required": false},
         {"name": "biosample_type", "datatype": "string", "array_of": false, "required": false},
-        {"name": "diagnosis_id", "datatype": "string", "array_of": true, "required": false},
         {"name": "disease", "datatype": "string", "array_of": false, "required": false},
         {"name": "donor_age_at_collection_unit", "datatype": "string", "array_of": false, "required": false},
         {"name": "donor_age_at_collection_lower_bound", "datatype": "float", "array_of": false, "required": false},
@@ -83,7 +82,7 @@
       "intPartitionOptions": null
     },
     {
-      "name": "dataset",
+      "name": "anvil_dataset",
       "columns": [
         {"name": "dataset_id", "datatype": "string", "array_of": false, "required": true},
         {"name": "consent_group", "datatype": "string", "array_of": true, "required": false},
@@ -101,9 +100,10 @@
       "intPartitionOptions": null
     },
     {
-      "name": "diagnosis",
+      "name": "anvil_diagnosis",
       "columns": [
         {"name": "diagnosis_id", "datatype": "string", "array_of": false, "required": true},
+        {"name": "donor_id", "datatype": "string", "array_of": false, "required": false},
         {"name": "disease", "datatype": "string", "array_of": true, "required": false},
         {"name": "diagnosis_age_unit", "datatype": "string", "array_of": false, "required": false},
         {"name": "diagnosis_age_lower_bound", "datatype": "float", "array_of": false, "required": false},
@@ -121,7 +121,7 @@
       "intPartitionOptions": null
     },
     {
-      "name": "donor",
+      "name": "anvil_donor",
       "columns": [
         {"name": "donor_id", "datatype": "string", "array_of": false, "required": true},
         {"name": "organism_type", "datatype": "string", "array_of": false, "required": false},
@@ -129,7 +129,6 @@
         {"name": "phenotypic_sex", "datatype": "string", "array_of": false, "required": false},
         {"name": "reported_ethnicity", "datatype": "string", "array_of": true, "required": false},
         {"name": "genetic_ancestry", "datatype": "string", "array_of": true, "required": false},
-        {"name": "diagnosis_id", "datatype": "string", "array_of": true, "required": false},
         {"name": "source_datarepo_row_ids", "datatype": "string", "array_of": true, "required": false}
       ],
       "primaryKey": ["donor_id"],
@@ -138,15 +137,15 @@
       "intPartitionOptions": null
     },
     {
-      "name": "file",
+      "name": "anvil_file",
       "columns": [
         {"name": "file_id", "datatype": "string", "array_of": false, "required": true},
         {"name": "data_modality", "datatype": "string", "array_of": true, "required": false},
         {"name": "file_format", "datatype": "string", "array_of": false, "required": false},
-        {"name": "byte_size", "datatype": "integer", "array_of": false, "required": false},
-        {"name": "md5_checksum", "datatype": "string", "array_of": false, "required": false},
+        {"name": "file_size", "datatype": "integer", "array_of": false, "required": false},
+        {"name": "file_md5sum", "datatype": "string", "array_of": false, "required": false},
         {"name": "reference_assembly", "datatype": "string", "array_of": true, "required": false},
-        {"name": "label", "datatype": "string", "array_of": false, "required": false},
+        {"name": "file_name", "datatype": "string", "array_of": false, "required": false},
         {"name": "file_ref", "datatype": "fileref", "array_of": false, "required": false},
         {"name": "source_datarepo_row_ids", "datatype": "string", "array_of": true, "required": false}
       ],
@@ -156,7 +155,7 @@
       "intPartitionOptions": null
     },
     {
-      "name": "project",
+      "name": "anvil_project",
       "columns": [
         {"name": "project_id", "datatype": "string", "array_of": false, "required": true},
         {"name": "funded_by", "datatype": "string", "array_of": true, "required": false},
@@ -172,7 +171,7 @@
       "intPartitionOptions": null
     },
     {
-      "name": "sequencingactivity",
+      "name": "anvil_sequencingactivity",
       "columns": [
         {"name": "sequencingactivity_id", "datatype": "string", "array_of": false, "required": true},
         {"name": "activity_type", "datatype": "string", "array_of": false, "required": false},
@@ -188,7 +187,7 @@
       "intPartitionOptions": null
     },
     {
-      "name": "variantcallingactivity",
+      "name": "anvil_variantcallingactivity",
       "columns": [
         {"name": "variantcallingactivity_id", "datatype": "string", "array_of": false, "required": true},
         {"name": "activity_type", "datatype": "string", "array_of": false, "required": false},
@@ -207,93 +206,88 @@
   "relationships": [
     {
       "name": "from_activity.used_file_id_to_file.file_id",
-      "from": {"table": "activity", "column": "used_file_id"},
-      "to": {"table": "file", "column": "file_id"}
+      "from": {"table": "anvil_activity", "column": "used_file_id"},
+      "to": {"table": "anvil_file", "column": "file_id"}
     },
     {
       "name": "from_activity.generated_file_id_to_file.file_id",
-      "from": {"table": "activity", "column": "generated_file_id"},
-      "to": {"table": "file", "column": "file_id"}
+      "from": {"table": "anvil_activity", "column": "generated_file_id"},
+      "to": {"table": "anvil_file", "column": "file_id"}
     },
     {
       "name": "from_activity.used_biosample_id_to_biosample.biosample_id",
-      "from": {"table": "activity", "column": "used_biosample_id"},
-      "to": {"table": "biosample", "column": "biosample_id"}
+      "from": {"table": "anvil_activity", "column": "used_biosample_id"},
+      "to": {"table": "anvil_biosample", "column": "biosample_id"}
     },
     {
       "name": "from_alignmentactivity.used_file_id_to_file.file_id",
-      "from": {"table": "alignmentactivity", "column": "used_file_id"},
-      "to": {"table": "file", "column": "file_id"}
+      "from": {"table": "anvil_alignmentactivity", "column": "used_file_id"},
+      "to": {"table": "anvil_file", "column": "file_id"}
     },
     {
       "name": "from_alignmentactivity.generated_file_id_to_file.file_id",
-      "from": {"table": "alignmentactivity", "column": "generated_file_id"},
-      "to": {"table": "file", "column": "file_id"}
+      "from": {"table": "anvil_alignmentactivity", "column": "generated_file_id"},
+      "to": {"table": "anvil_file", "column": "file_id"}
     },
     {
       "name": "from_assayactivity.antibody_id_to_antibody.antibody_id",
-      "from": {"table": "assayactivity", "column": "antibody_id"},
-      "to": {"table": "antibody", "column": "antibody_id"}
+      "from": {"table": "anvil_assayactivity", "column": "antibody_id"},
+      "to": {"table": "anvil_antibody", "column": "antibody_id"}
     },
     {
       "name": "from_assayactivity.generated_file_id_to_file.file_id",
-      "from": {"table": "assayactivity", "column": "generated_file_id"},
-      "to": {"table": "file", "column": "file_id"}
+      "from": {"table": "anvil_assayactivity", "column": "generated_file_id"},
+      "to": {"table": "anvil_file", "column": "file_id"}
     },
     {
       "name": "from_assayactivity.used_biosample_id_to_biosample.biosample_id",
-      "from": {"table": "assayactivity", "column": "used_biosample_id"},
-      "to": {"table": "biosample", "column": "biosample_id"}
-    },
-    {
-      "name": "from_biosample.diagnosis_id_to_diagnosis.diagnosis_id",
-      "from": {"table": "biosample", "column": "diagnosis_id"},
-      "to": {"table": "diagnosis", "column": "diagnosis_id"}
+      "from": {"table": "anvil_assayactivity", "column": "used_biosample_id"},
+      "to": {"table": "anvil_biosample", "column": "biosample_id"}
     },
     {
       "name": "from_biosample.donor_id_to_donor.donor_id",
-      "from": {"table": "biosample", "column": "donor_id"},
-      "to": {"table": "donor", "column": "donor_id"}
+      "from": {"table": "anvil_biosample", "column": "donor_id"},
+      "to": {"table": "anvil_donor", "column": "donor_id"}
     },
     {
       "name": "from_biosample.part_of_dataset_id_to_dataset.dataset_id",
-      "from": {"table": "biosample", "column": "part_of_dataset_id"},
-      "to": {"table": "dataset", "column": "dataset_id"}
+      "from": {"table": "anvil_biosample", "column": "part_of_dataset_id"},
+      "to": {"table": "anvil_dataset", "column": "dataset_id"}
     },
     {
       "name": "from_donor.part_of_dataset_id_to_dataset.dataset_id",
-      "from": {"table": "donor", "column": "part_of_dataset_id"},
-      "to": {"table": "dataset", "column": "dataset_id"}
+      "from": {"table": "anvil_donor", "column": "part_of_dataset_id"},
+      "to": {"table": "anvil_dataset", "column": "dataset_id"}
     },
     {
       "name": "from_donor.diagnosis_id_to_diagnosis.diagnosis_id",
-      "from": {"table": "donor", "column": "diagnosis_id"},
-      "to": {"table": "diagnosis", "column": "diagnosis_id"}
+      "from": {"table": "anvil_donor", "column": "diagnosis_id"},
+      "to": {"table": "anvil_diagnosis", "column": "diagnosis_id"}
     },
     {
       "name": "from_project.generated_dataset_id_to_dataset.dataset_id",
-      "from": {"table": "project", "column": "generated_dataset_id"},
-      "to": {"table": "dataset", "column": "dataset_id"}
+      "from": {"table": "anvil_project", "column": "generated_dataset_id"},
+      "to": {"table": "anvil_dataset", "column": "dataset_id"}
     },
     {
       "name": "from_sequencingactivity.generated_file_id_to_file.file_id",
-      "from": {"table": "sequencingactivity", "column": "generated_file_id"},
-      "to": {"table": "file", "column": "file_id"}
+      "from": {"table": "anvil_sequencingactivity", "column": "generated_file_id"},
+      "to": {"table": "anvil_file", "column": "file_id"}
     },
     {
       "name": "from_sequencingactivity.used_biosample_id_to_biosample.biosample_id",
-      "from": {"table": "sequencingactivity", "column": "used_biosample_id"},
-      "to": {"table": "biosample", "column": "biosample_id"}
+      "from": {"table": "anvil_sequencingactivity", "column": "used_biosample_id"},
+      "to": {"table": "anvil_biosample", "column": "biosample_id"}
     },
     {
       "name": "from_variantcallingactivity.used_file_id_to_file.file_id",
-      "from": {"table": "variantcallingactivity", "column": "used_file_id"},
-      "to": {"table": "file", "column": "file_id"}
+      "from": {"table": "anvil_variantcallingactivity", "column": "used_file_id"},
+      "to": {"table": "anvil_file", "column": "file_id"}
     },
     {
       "name": "from_variantcallingactivity.generated_file_id_to_file.file_id",
-      "from": {"table": "variantcallingactivity", "column": "generated_file_id"},
-      "to": {"table": "file", "column": "file_id"}
+      "from": {"table": "anvil_variantcallingactivity", "column": "generated_file_id"},
+      "to": {"table": "anvil_file", "column": "file_id"}
     }
   ]
 }


### PR DESCRIPTION
Changes (outlined in DI-149) include:
- Prefixing all tables (and references to tables in relationships) with "anvil_" to differentiate them from the source dataset tables (which we'd prefer to leave as-is if possible). 
- Switch the directionality of the relationships between donor and diagnosis (i.e. add a donor_id FK to diagnosis that points to donor.donor_id and subsequently remove donor.diagnosis_id). Also remove relationship between biosample and diagnosis.
- Update some field names to more align with NCPI Common Attribute names (where appropriate).